### PR TITLE
chore: automate upstream sync to develop and PR to main

### DIFF
--- a/.github/workflows/create-develop-to-main-pr.yml
+++ b/.github/workflows/create-develop-to-main-pr.yml
@@ -1,0 +1,65 @@
+name: Create or Update Develop to Main PR
+
+on:
+  workflow_run:
+    workflows: ["Sync Upstream to Develop"]
+    types: [completed]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: develop-to-main-pr
+  cancel-in-progress: false
+
+jobs:
+  pr:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Ensure branches are up to date
+        run: |
+          set -euo pipefail
+          git fetch origin main develop
+
+      - name: Create or update develop to main PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          AHEAD_BY=$(gh api "repos/$REPO/compare/main...develop" --jq '.ahead_by')
+
+          if [ "$AHEAD_BY" -le 0 ]; then
+            echo "No commits to merge from develop into main."
+            exit 0
+          fi
+
+          OPEN_PR_NUMBER=$(gh pr list \
+            --repo "$REPO" \
+            --state open \
+            --base main \
+            --head develop \
+            --json number \
+            --jq '.[0].number')
+
+          if [ -n "$OPEN_PR_NUMBER" ]; then
+            echo "Open PR #$OPEN_PR_NUMBER already exists for develop -> main."
+            gh pr comment "$OPEN_PR_NUMBER" --repo "$REPO" --body "Automated update: develop now includes new upstream sync commits."
+            exit 0
+          fi
+
+          gh pr create \
+            --repo "$REPO" \
+            --base main \
+            --head develop \
+            --title "chore: sync develop into main" \
+            --body "## Automated Sync PR\n\nThis pull request was created automatically after syncing \`upstream/main\` into \`develop\`.\n\n- Source branch: \`develop\`\n- Target branch: \`main\`\n- Trigger: scheduled/manual upstream sync workflow\n\nPlease review and merge when ready."

--- a/.github/workflows/sync-upstream-to-develop.yml
+++ b/.github/workflows/sync-upstream-to-develop.yml
@@ -1,0 +1,92 @@
+name: Sync Upstream to Develop
+
+on:
+  schedule:
+    - cron: "30 2 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: sync-upstream-to-develop
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.sync.outputs.changed }}
+      merge_conflict: ${{ steps.sync.outputs.merge_conflict }}
+      develop_sha: ${{ steps.sync.outputs.develop_sha }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure git identity
+        run: |
+          git config user.name "openalgo-sync-bot"
+          git config user.email "openalgo-sync-bot@users.noreply.github.com"
+
+      - name: Sync upstream/main into develop
+        id: sync
+        run: |
+          set -euo pipefail
+
+          if git remote get-url upstream > /dev/null 2>&1; then
+            git remote set-url upstream https://github.com/marketcalls/openalgo.git
+          else
+            git remote add upstream https://github.com/marketcalls/openalgo.git
+          fi
+
+          git fetch upstream main
+          git fetch origin main
+
+          if git ls-remote --exit-code --heads origin develop > /dev/null 2>&1; then
+            git fetch origin develop
+            git checkout -B develop origin/develop
+          else
+            git checkout -B develop origin/main
+            git push -u origin develop
+          fi
+
+          BEFORE_SHA=$(git rev-parse HEAD)
+
+          set +e
+          git merge --no-edit upstream/main
+          MERGE_EXIT=$?
+          set -e
+
+          if [ "$MERGE_EXIT" -ne 0 ]; then
+            echo "merge_conflict=true" >> "$GITHUB_OUTPUT"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "develop_sha=$BEFORE_SHA" >> "$GITHUB_OUTPUT"
+            {
+              echo "## Upstream Sync Conflict"
+              echo "Automatic sync failed with merge conflicts in these files:"
+              git diff --name-only --diff-filter=U | sed 's/^/- /'
+              echo
+              echo "Resolve conflicts on branch develop and re-run this workflow."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          AFTER_SHA=$(git rev-parse HEAD)
+          echo "merge_conflict=false" >> "$GITHUB_OUTPUT"
+          echo "develop_sha=$AFTER_SHA" >> "$GITHUB_OUTPUT"
+
+          if [ "$BEFORE_SHA" = "$AFTER_SHA" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No new upstream commits to sync." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          git push origin develop
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          {
+            echo "## Upstream Sync Completed"
+            echo "- Previous develop SHA: $BEFORE_SHA"
+            echo "- New develop SHA: $AFTER_SHA"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -473,6 +473,32 @@ Closes #456
 - [x] No breaking changes to existing code
 ```
 
+### 8. Automated Fork Sync (Maintainers)
+
+This repository includes GitHub Actions workflows to keep a fork aligned with upstream and prepare merge PRs.
+
+1. `Sync Upstream to Develop`
+    - Runs daily and on manual dispatch.
+    - Merges `upstream/main` into `develop`.
+    - Creates `develop` from `main` if it does not exist yet.
+    - Stops safely on merge conflicts (no force push).
+
+2. `Create or Update Develop to Main PR`
+    - Runs after a successful upstream sync and on manual dispatch.
+    - Creates a `develop` to `main` PR only when `develop` is ahead.
+    - Keeps one open PR only. After merge, a new PR is created on the next sync with new commits.
+
+Repository settings required:
+
+- `Settings` > `Actions` > `General` > `Workflow permissions` > `Read and write permissions`
+- Enable `Allow GitHub Actions to create and approve pull requests`
+
+Manual recovery option:
+
+```bash
+./scripts/update_from_upstream.sh --remote upstream --branch main --strategy merge
+```
+
 ---
 
 ## Contributing Guidelines


### PR DESCRIPTION
## Summary
- add a scheduled workflow to sync `upstream/main` into `develop`
- add a follow-up workflow to create/update a single `develop -> main` PR
- document required GitHub Actions permissions and manual recovery in `CONTRIBUTING.md`

## Why
Fork branch drift happened because workflow automation files were missing. This change adds idempotent automation so:
- `develop` is kept current from upstream
- one open `develop -> main` PR is maintained
- a new PR is created after previous merge when new sync commits arrive

## Notes
- sync workflow fails safely on merge conflicts (no force-push)
- if `develop` does not exist, it is created from `main`

## Validation
- workflow syntax checked locally
- branch pushed to fork successfully